### PR TITLE
chore: bump version to v0.6.1-tabia.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.whatsapp.api</groupId>
     <artifactId>whatsapp-business-java-api</artifactId>
-    <version>v0.6.1-tabia.1</version>
+    <version>v0.6.1-tabia.2</version>
     <licenses>
         <license>
             <name>The MIT License</name>


### PR DESCRIPTION
## Summary

- Bump project version from `v0.6.1-tabia.1` → `v0.6.1-tabia.2`
- Includes Graph API versions v21.0–v25.0 (merged via PR #6)
- Sets v25.0 as the default API version in `WhatsappApiConfig`

## After merging

Create the git tag to trigger JitPack build:

```bash
git tag v0.6.1-tabia.2
git push origin v0.6.1-tabia.2
```

Then update CareOS `modules/messaging/pom.xml`:

```xml
<version>v0.6.1-tabia.2</version>
```